### PR TITLE
Now all shorthands works with "()"

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ using(db.conn(), function (conn) {
         set coins = coins + 10 \
         where user_id=$1',
         [4]
-    )).then(DBH.commit);
-    // noted that is DBH.commit, not DBH.commit()
+    )).then(DBH.commit());
 });
 ```
 

--- a/test/db.js
+++ b/test/db.js
@@ -124,7 +124,7 @@ describe('DBH', function() {
                     .then(function (name) {
                         assert.equal(name, oldName);
                     })
-                    .then(DBH.begin) // start transaction
+                    .then(DBH.begin()) // start transaction
                     .then(DBH.update('person', { name: newName }, { id: id }));
                 // because not commit is here, then auto rollback must be called
             }).then(function () {
@@ -149,9 +149,9 @@ describe('DBH', function() {
                     .then(function (name) {
                         assert.equal(name, oldName);
                     })
-                    .then(DBH.begin) // start transaction
+                    .then(DBH.begin()) // start transaction
                     .then(DBH.update('person', { name: newName }, { id: id }))
-                    .then(DBH.commit);
+                    .then(DBH.commit());
             }).then(function () {
                 return using(db.conn(), function (conn) {
                     return conn.fetchScalar(query)


### PR DESCRIPTION
DBH.commit -> DBH.commit()
